### PR TITLE
Create interactive TarotTeller CLI experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+
+# Test and coverage artifacts
+.pytest_cache/
+htmlcov/
+.coverage*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
 # TarotTeller
+
+TarotTeller is an immersive Python command-line companion that blends five divination traditions into a single, story-rich reading:
+
+1. Western horoscope insights
+2. Chinese zodiac wisdom
+3. Native American medicine wheel guidance
+4. Chaldean numerology vibrations
+5. A three-card tarot spread
+
+The experience is intentionally interactive. TarotTeller asks for your name, birthdate, favourite colour, and an optional intention so it can tailor every paragraph of the reading to you.
+
+## Getting started
+
+TarotTeller relies only on Python's standard library. To explore the reading:
+
+```bash
+python -m tarot_teller
+```
+
+You can optionally make the tarot spread reproducible by passing a seed value:
+
+```bash
+python -m tarot_teller --seed 42
+```
+
+## Running the tests
+
+A lightweight pytest suite verifies zodiac boundaries, numerology reductions, tarot spreads, and overall reading composition.
+
+```bash
+python -m pytest
+```
+
+## Project structure
+
+```
+tarot_teller/
+├── __init__.py                # Package exports
+├── __main__.py                # CLI entry point
+├── astrology.py               # Western + Chinese zodiac logic
+├── native_american.py         # Medicine wheel totem insights
+├── numerology.py              # Chaldean numerology helpers
+├── reading.py                 # Orchestrates the full reading
+├── tarot.py                   # Tarot deck + spread utilities
+└── user.py                    # Interactive prompts and profile model
+```
+
+The `tests/` directory contains unit tests to keep future enhancements grounded.
+
+## Extending TarotTeller
+
+TarotTeller was designed with modularity in mind. Each tradition lives in its own module, making it straightforward to:
+
+- swap in alternative data sets (e.g., add more tarot spreads or numerology interpretations),
+- build a GUI around `craft_full_reading`, or
+- integrate additional cultural wisdom traditions.
+
+Pull requests and mystical ideas are always welcome. ✨

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=67"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tarot-teller"
+version = "0.1.0"
+description = "Interactive command-line experience that synthesizes astrology, numerology, and tarot insights."
+authors = [{name = "TarotTeller Contributors"}]
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=7"]
+
+[tool.pytest.ini_options]
+addopts = "-q"
+pythonpath = ["."]

--- a/tarot_teller/__init__.py
+++ b/tarot_teller/__init__.py
@@ -1,0 +1,6 @@
+"""TarotTeller package."""
+
+from .reading import FullReading, craft_full_reading
+from .user import UserProfile
+
+__all__ = ["FullReading", "UserProfile", "craft_full_reading"]

--- a/tarot_teller/__main__.py
+++ b/tarot_teller/__main__.py
@@ -1,0 +1,30 @@
+"""Command line interface for TarotTeller."""
+
+from __future__ import annotations
+
+import argparse
+import random
+
+from .reading import craft_full_reading
+from .user import collect_user_profile
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Receive an immersive TarotTeller reading.")
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Optional random seed to make the tarot spread deterministic.",
+    )
+    args = parser.parse_args()
+
+    user = collect_user_profile()
+    rng = random.Random(args.seed) if args.seed is not None else None
+    reading = craft_full_reading(user, rng=rng)
+    print()
+    print(reading.render())
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()

--- a/tarot_teller/astrology.py
+++ b/tarot_teller/astrology.py
@@ -1,0 +1,115 @@
+"""Astrological insights for TarotTeller."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+
+@dataclass(frozen=True)
+class ZodiacInsight:
+    sign: str
+    element: str
+    ruling_planet: str
+    summary: str
+
+
+_ZODIAC_DATA = [
+    ((1, 20), "Aquarius", "Air", "Saturn & Uranus", "The visionary water bearer balancing intellect with humanitarian heart."),
+    ((2, 19), "Pisces", "Water", "Jupiter & Neptune", "An empathic dreamer guided by intuition and compassionate creativity."),
+    ((3, 21), "Aries", "Fire", "Mars", "A courageous spark ready to initiate bold adventures."),
+    ((4, 20), "Taurus", "Earth", "Venus", "A steady soul who cultivates beauty, comfort, and tangible progress."),
+    ((5, 21), "Gemini", "Air", "Mercury", "A quicksilver messenger weaving curiosity into insight."),
+    ((6, 21), "Cancer", "Water", "Moon", "A lunar nurturer protecting emotional truth and chosen family."),
+    ((7, 23), "Leo", "Fire", "Sun", "A radiant heart-leader who shines through generosity and creativity."),
+    ((8, 23), "Virgo", "Earth", "Mercury", "An intuitive analyst harmonizing practicality with mindful service."),
+    ((9, 23), "Libra", "Air", "Venus", "A diplomatic balancer seeking harmony, justice, and aesthetic grace."),
+    ((10, 23), "Scorpio", "Water", "Mars & Pluto", "A mystic alchemist transforming through depth and devotion."),
+    ((11, 22), "Sagittarius", "Fire", "Jupiter", "An expansive truth-seeker roaming between wisdom and wonder."),
+    ((12, 22), "Capricorn", "Earth", "Saturn", "A mountain climber crafting legacy through discipline and heart."),
+]
+
+
+def western_zodiac_for(birthdate: date) -> ZodiacInsight:
+    """Return the western zodiac insight for ``birthdate``."""
+
+    month_day = (birthdate.month, birthdate.day)
+    insight_data = _ZODIAC_DATA[-1]
+    for index, (start, sign, element, planet, summary) in enumerate(_ZODIAC_DATA):
+        if month_day < start:
+            insight_data = _ZODIAC_DATA[index - 1]
+            break
+    else:
+        # month_day is on or after the final start boundary (Capricorn) and should
+        # therefore default to Capricorn from the initial assignment above.
+        pass
+
+    _, sign, element, planet, summary = insight_data
+    return ZodiacInsight(sign=sign, element=element, ruling_planet=planet, summary=summary)
+
+
+_CHINESE_ANIMALS = [
+    "Rat",
+    "Ox",
+    "Tiger",
+    "Rabbit",
+    "Dragon",
+    "Snake",
+    "Horse",
+    "Goat",
+    "Monkey",
+    "Rooster",
+    "Dog",
+    "Pig",
+]
+
+_CHINESE_TRAITS = {
+    "Rat": "strategic, charming, and resourceful when navigating changing tides.",
+    "Ox": "patient, steadfast, and devoted to purposeful progress.",
+    "Tiger": "courageous, magnetic, and ready to champion the underdog.",
+    "Rabbit": "artistic, gentle, and a natural curator of peaceful spaces.",
+    "Dragon": "dynamic, visionary, and able to catalyze collective momentum.",
+    "Snake": "intuitive, refined, and wise in the art of timing.",
+    "Horse": "restless, free-spirited, and happiest chasing open horizons.",
+    "Goat": "tender-hearted, imaginative, and committed to cooperative harmony.",
+    "Monkey": "clever, playful, and ingenious when solving intricate puzzles.",
+    "Rooster": "confident, precise, and devoted to uplifting community standards.",
+    "Dog": "loyal, sincere, and moved by a strong moral compass.",
+    "Pig": "kind, generous, and gifted at transmuting challenges into abundance.",
+}
+
+
+@dataclass(frozen=True)
+class ChineseZodiacInsight:
+    animal: str
+    element_cycle: str
+    summary: str
+
+
+def chinese_zodiac_for(birthdate: date) -> ChineseZodiacInsight:
+    """Return the Chinese zodiac insight for ``birthdate``."""
+
+    cycle_index = (birthdate.year - 1900) % len(_CHINESE_ANIMALS)
+    animal = _CHINESE_ANIMALS[cycle_index]
+    element_cycle = _five_element_cycle(birthdate.year)
+    summary = _CHINESE_TRAITS[animal]
+    return ChineseZodiacInsight(animal=animal, element_cycle=element_cycle, summary=summary)
+
+
+def _five_element_cycle(year: int) -> str:
+    elements = [
+        "Metal",
+        "Metal",
+        "Water",
+        "Water",
+        "Wood",
+        "Wood",
+        "Fire",
+        "Fire",
+        "Earth",
+        "Earth",
+    ]
+    index = (year - 1900) % len(elements)
+    element = elements[index]
+    yin_yang = "Yang" if ((year - 1900) % 2 == 0) else "Yin"
+    return f"{yin_yang} {element}"

--- a/tarot_teller/native_american.py
+++ b/tarot_teller/native_american.py
@@ -1,0 +1,82 @@
+"""Native American medicine wheel insights."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import NamedTuple, Sequence
+
+
+class _TotemRange(NamedTuple):
+    start: tuple[int, int]
+    end: tuple[int, int]
+    totem: str
+    element: str
+    clan: str
+    keywords: Sequence[str]
+
+
+_TOTEM_RANGES: list[_TotemRange] = [
+    _TotemRange((1, 20), (2, 18), "Otter", "Air", "Butterfly Clan", ("inventive", "supportive", "compassionate")),
+    _TotemRange((2, 19), (3, 20), "Wolf", "Water", "Frog Clan", ("romantic", "intuitive", "protective")),
+    _TotemRange((3, 21), (4, 19), "Falcon", "Fire", "Hawk Clan", ("sharp-eyed", "strategic", "decisive")),
+    _TotemRange((4, 20), (5, 20), "Beaver", "Earth", "Turtle Clan", ("resourceful", "grounded", "collaborative")),
+    _TotemRange((5, 21), (6, 20), "Deer", "Air", "Butterfly Clan", ("playful", "inspiring", "quick-witted")),
+    _TotemRange((6, 21), (7, 21), "Woodpecker", "Water", "Frog Clan", ("nurturing", "rhythmic", "devoted")),
+    _TotemRange((7, 22), (8, 21), "Salmon", "Fire", "Hawk Clan", ("driven", "generous", "creative")),
+    _TotemRange((8, 22), (9, 21), "Bear", "Earth", "Turtle Clan", ("practical", "patient", "healing")),
+    _TotemRange((9, 22), (10, 22), "Raven", "Air", "Butterfly Clan", ("diplomatic", "visionary", "transformative")),
+    _TotemRange((10, 23), (11, 21), "Snake", "Water", "Frog Clan", ("mystical", "adaptable", "catalytic")),
+    _TotemRange((11, 22), (12, 21), "Owl", "Fire", "Hawk Clan", ("perceptive", "truth-seeking", "philosophical")),
+    _TotemRange((12, 22), (1, 19), "Goose", "Earth", "Turtle Clan", ("ambitious", "enduring", "community-minded")),
+]
+
+
+@dataclass(frozen=True)
+class TotemInsight:
+    totem: str
+    element: str
+    clan: str
+    keywords: tuple[str, ...]
+    message: str
+
+
+def totem_for(birthdate: date) -> TotemInsight:
+    month_day = (birthdate.month, birthdate.day)
+
+    for totem_range in _TOTEM_RANGES:
+        if _in_range(month_day, totem_range.start, totem_range.end):
+            message = _craft_message(totem_range)
+            return TotemInsight(
+                totem=totem_range.totem,
+                element=totem_range.element,
+                clan=totem_range.clan,
+                keywords=tuple(totem_range.keywords),
+                message=message,
+            )
+
+    raise ValueError("No totem range found; check configuration data.")
+
+
+def _in_range(value: tuple[int, int], start: tuple[int, int], end: tuple[int, int]) -> bool:
+    if start <= end:
+        return start <= value <= end
+    # Handles wrap-around (Goose range across new year).
+    return value >= start or value <= end
+
+
+def _craft_message(totem_range: _TotemRange) -> str:
+    qualities = _join_words(totem_range.keywords)
+    return (
+        f"The {totem_range.totem} walks with you as part of the {totem_range.clan}. "
+        f"This medicine wheel position emphasizes {totem_range.element.lower()} element wisdom—"
+        f"expect your {qualities} nature to open doors for deeper belonging and reciprocity."
+    )
+
+
+def _join_words(words: Sequence[str]) -> str:
+    if not words:
+        return ""
+    if len(words) == 1:
+        return words[0]
+    return ", ".join(words[:-1]) + f", and {words[-1]}"

--- a/tarot_teller/numerology.py
+++ b/tarot_teller/numerology.py
@@ -1,0 +1,133 @@
+"""Chaldean numerology helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+import unicodedata
+
+
+_CHALDEAN_MAP = {
+    "A": 1,
+    "I": 1,
+    "J": 1,
+    "Q": 1,
+    "Y": 1,
+    "B": 2,
+    "K": 2,
+    "R": 2,
+    "C": 3,
+    "G": 3,
+    "L": 3,
+    "S": 3,
+    "D": 4,
+    "M": 4,
+    "T": 4,
+    "E": 5,
+    "H": 5,
+    "N": 5,
+    "X": 5,
+    "U": 6,
+    "V": 6,
+    "W": 6,
+    "O": 7,
+    "Z": 7,
+    "F": 8,
+    "P": 8,
+}
+
+_MASTER_NUMBERS = {11, 22}
+
+_NAME_MEANINGS = {
+    1: "Leadership, pioneering spirit, and the courage to forge your own path.",
+    2: "Diplomacy, empathy, and the gift of weaving people together.",
+    3: "Creative expression, optimism, and the joy of storytelling.",
+    4: "Steadfast structure, reliability, and craftsmanship in all pursuits.",
+    5: "Adventure, adaptability, and a restless hunger for experience.",
+    6: "Nurturing guardianship, harmony, and heart-centered responsibility.",
+    7: "Mysticism, introspection, and the pursuit of deeper truths.",
+    8: "Manifestation, executive power, and wise stewardship of resources.",
+    11: "Visionary insight and the ability to illuminate the collective imagination.",
+    22: "Master builder energy capable of turning bold ideals into reality.",
+}
+
+_BIRTH_MEANINGS = {
+    1: "You thrive when taking initiative and trusting your instincts.",
+    2: "Your life path is enriched through cooperation and attentive listening.",
+    3: "You flourish by communicating, teaching, and inspiring.",
+    4: "Consistent effort and grounded planning are your superpowers.",
+    5: "Freedom and variety keep your spirit animated—keep exploring.",
+    6: "Service and community caretaking bring you soulful satisfaction.",
+    7: "Quiet study, contemplation, and spiritual inquiry recharge you.",
+    8: "You are learning to balance ambition with integrity and generosity.",
+    9: "Your path asks for compassion, artistic contribution, and letting go.",
+    11: "You are tuned to synchronicity—share your intuitive downloads.",
+    22: "Architect your visions with patience; they can uplift many.",
+}
+
+
+@dataclass(frozen=True)
+class NumerologyInsight:
+    name_number: int
+    birth_number: int
+    name_breakdown: tuple[tuple[str, int], ...]
+    summary: str
+
+
+def chaldean_numerology_for(name: str, birthdate: date) -> NumerologyInsight:
+    cleaned = _normalize_name(name)
+    breakdown: list[tuple[str, int]] = []
+    total = 0
+    for char in cleaned:
+        value = _CHALDEAN_MAP.get(char)
+        if value is None:
+            continue
+        breakdown.append((char, value))
+        total += value
+
+    name_number = _reduce_number(total)
+    birth_number = _reduce_number(sum(int(digit) for digit in birthdate.strftime("%Y%m%d")))
+
+    summary = _summarize(name_number, birth_number)
+
+    return NumerologyInsight(
+        name_number=name_number,
+        birth_number=birth_number,
+        name_breakdown=tuple(breakdown),
+        summary=summary,
+    )
+
+
+def _normalize_name(name: str) -> str:
+    normalized = unicodedata.normalize("NFKD", name)
+    return "".join(c for c in normalized.upper() if c.isalpha())
+
+
+def _reduce_number(value: int) -> int:
+    while value not in _MASTER_NUMBERS and value >= 10:
+        value = sum(int(digit) for digit in str(value))
+    return value
+
+
+def _summarize(name_number: int, birth_number: int) -> str:
+    name_meaning = _NAME_MEANINGS.get(name_number)
+    birth_meaning = _BIRTH_MEANINGS.get(birth_number)
+
+    parts: list[str] = []
+    if name_meaning:
+        parts.append(
+            f"Your Chaldean name number is {name_number}, highlighting {name_meaning}"
+        )
+    else:
+        parts.append(
+            "Your Chaldean name number carries a unique vibration beyond the traditional canon."
+        )
+
+    if birth_meaning:
+        parts.append(f"Your birth number {birth_number} suggests {birth_meaning}")
+    else:
+        parts.append(
+            "Your birth number adds an unconventional rhythm—trust the path unfolding before you."
+        )
+
+    return " ".join(parts)

--- a/tarot_teller/reading.py
+++ b/tarot_teller/reading.py
@@ -1,0 +1,181 @@
+"""Create the full TarotTeller experience."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import random
+from textwrap import dedent
+
+from .astrology import ChineseZodiacInsight, ZodiacInsight, chinese_zodiac_for, western_zodiac_for
+from .native_american import TotemInsight, totem_for
+from .numerology import NumerologyInsight, chaldean_numerology_for
+from .tarot import TarotReading, draw_three_card_spread
+from .user import UserProfile
+
+
+@dataclass(frozen=True)
+class FullReading:
+    user: UserProfile
+    western_zodiac: ZodiacInsight
+    chinese_zodiac: ChineseZodiacInsight
+    totem: TotemInsight
+    numerology: NumerologyInsight
+    tarot: TarotReading
+    color_message: str
+
+    def render(self) -> str:
+        user = self.user
+        greeting = _greeting_section(user.name, user.favorite_color, self.color_message, user.intention)
+        astro_section = _astro_section(self.western_zodiac, self.chinese_zodiac)
+        totem_section = _totem_section(self.totem)
+        numerology_section = _numerology_section(self.numerology)
+        tarot_section = _tarot_section(self.tarot)
+        synthesis = _synthesis_section(self.western_zodiac, self.chinese_zodiac, self.totem, self.numerology, self.tarot)
+
+        return "\n\n".join(
+            (
+                greeting,
+                astro_section,
+                totem_section,
+                numerology_section,
+                tarot_section,
+                synthesis,
+            )
+        )
+
+
+def craft_full_reading(user: UserProfile, rng: random.Random | None = None) -> FullReading:
+    western = western_zodiac_for(user.birthdate)
+    chinese = chinese_zodiac_for(user.birthdate)
+    totem = totem_for(user.birthdate)
+    numerology = chaldean_numerology_for(user.name, user.birthdate)
+    tarot = draw_three_card_spread(rng)
+    color_message = _interpret_color(user.favorite_color)
+
+    return FullReading(
+        user=user,
+        western_zodiac=western,
+        chinese_zodiac=chinese,
+        totem=totem,
+        numerology=numerology,
+        tarot=tarot,
+        color_message=color_message,
+    )
+
+
+_COLOR_SYMBOLISM = {
+    "RED": "bold self-advocacy and the ignition of passion projects.",
+    "ORANGE": "sacral creativity, confident networking, and vibrant collaboration.",
+    "YELLOW": "solar joy, intellect, and the courage to be seen.",
+    "GREEN": "healing growth, heart-led leadership, and prosperity.",
+    "BLUE": "truthful communication, emotional soothing, and spiritual listening.",
+    "PURPLE": "psychic attunement, nobility of purpose, and intuitive mastery.",
+    "PINK": "tender self-compassion, romance, and gentle rejuvenation.",
+    "BLACK": "protection, potent boundaries, and the power of mystery.",
+    "WHITE": "purification, clarity, and luminous new beginnings.",
+    "GOLD": "sovereignty, celebratory success, and generosity of spirit.",
+    "SILVER": "moonlit reflection, adaptability, and receptive magic.",
+}
+
+
+def _interpret_color(color: str) -> str:
+    key = color.strip().upper()
+    if key in _COLOR_SYMBOLISM:
+        return _COLOR_SYMBOLISM[key]
+    if " " in key:
+        for word in key.split():
+            if word in _COLOR_SYMBOLISM:
+                return _COLOR_SYMBOLISM[word]
+    return "a personally significant vibration—trust the feeling it evokes in you."
+
+
+def _greeting_section(name: str, color: str, color_message: str, intention: str | None) -> str:
+    intention_text = (
+        f"You asked me to hold the intention of '{intention}'. I kept that focus while weaving this reading."
+        if intention
+        else "You invited a general reading, so I listened for the themes most alive around you."
+    )
+    return dedent(
+        f"""
+        ✨ Welcome, {name}!\n
+        Tonight I light a {color.lower()} candle in your honor; this hue resonates with {color_message}
+        and threads its resonance through every insight that follows. {intention_text}
+        """
+    ).strip()
+
+
+def _astro_section(western: ZodiacInsight, chinese: ChineseZodiacInsight) -> str:
+    return dedent(
+        f"""
+        🌌 Celestial Alignments\n
+        In western astrology you are a {western.sign}, an {western.element.lower()} sign guided by {western.ruling_planet}.
+        {western.summary}
+
+        Your Chinese zodiac ally is the {chinese.animal} within the {chinese.element_cycle} year cycle. This energy is {chinese.summary}
+        and it nudges you to balance patience with swift intuitive action over the coming weeks.
+        """
+    ).strip()
+
+
+def _totem_section(totem: TotemInsight) -> str:
+    qualities = _join_keywords(totem.keywords)
+    return dedent(
+        f"""
+        🪶 Medicine Wheel Guidance\n
+        The {totem.totem} totem from the {totem.clan} greets you, radiating {qualities} qualities.
+        {totem.message}
+        """
+    ).strip()
+
+
+def _numerology_section(numerology: NumerologyInsight) -> str:
+    breakdown = ", ".join(f"{char}={value}" for char, value in numerology.name_breakdown)
+    if not breakdown:
+        breakdown = "(no letters mapped—consider providing a different name or nickname)"
+    return dedent(
+        f"""
+        🔢 Chaldean Numerology\n
+        Name vibration breakdown: {breakdown}. {numerology.summary}
+        Together these frequencies encourage you to notice repeating numbers, serendipities, and subtle invitations this week.
+        """
+    ).strip()
+
+
+def _tarot_section(tarot: TarotReading) -> str:
+    return dedent(
+        f"""
+        🃏 Three-Card Tarot Spread\n
+        {tarot.summary()}
+        These cards form a narrative arc from what shaped you to what is emerging—feel into where each sentence lands in your body.
+        """
+    ).strip()
+
+
+def _synthesis_section(
+    western: ZodiacInsight,
+    chinese: ChineseZodiacInsight,
+    totem: TotemInsight,
+    numerology: NumerologyInsight,
+    tarot: TarotReading,
+) -> str:
+    anchor = tarot.spread[-1].card.name if tarot.spread else "your evolving story"
+    totem_qualities = _join_keywords(totem.keywords)
+    return dedent(
+        f"""
+        🔮 Integrated Message\n
+        Threads from your {western.sign} sun, {chinese.animal} year, and {totem.totem} medicine weave a tapestry of
+        {totem_qualities} resilience. Numerology reminds you that your name and birth promise resonate with
+        numbers {numerology.name_number} and {numerology.birth_number}; let these guideposts support your decisions.
+
+        As you move forward, imagine the wisdom of {anchor.lower()} illuminating your path. Journal, meditate, or create a ritual
+        around these themes within the next three days to anchor them into everyday life. Your guides and ancestors are listening.
+        """
+    ).strip()
+
+
+def _join_keywords(words: tuple[str, ...]) -> str:
+    if not words:
+        return ""
+    if len(words) == 1:
+        return words[0]
+    return ", ".join(words[:-1]) + f", and {words[-1]}"

--- a/tarot_teller/tarot.py
+++ b/tarot_teller/tarot.py
@@ -1,0 +1,78 @@
+"""Tarot card mechanics for TarotTeller."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import random
+from typing import Iterable, Sequence
+
+
+@dataclass(frozen=True)
+class TarotCard:
+    name: str
+    keywords: tuple[str, ...]
+    upright: str
+
+
+@dataclass(frozen=True)
+class SpreadCard:
+    position: str
+    card: TarotCard
+
+    def narrative(self) -> str:
+        keyword_phrase = _join_keywords(self.card.keywords)
+        return (
+            f"{self.position}: {self.card.name} ({keyword_phrase}). {self.card.upright}"
+        )
+
+
+@dataclass(frozen=True)
+class TarotReading:
+    spread: tuple[SpreadCard, ...]
+
+    def summary(self) -> str:
+        lines = [entry.narrative() for entry in self.spread]
+        return "\n".join(lines)
+
+
+def draw_three_card_spread(rng: random.Random | None = None) -> TarotReading:
+    rng = rng or random.Random()
+    cards = rng.sample(_MAJOR_ARCANA, 3)
+    positions = ("Past", "Present", "Future")
+    spread = tuple(SpreadCard(position, card) for position, card in zip(positions, cards))
+    return TarotReading(spread=spread)
+
+
+_MAJOR_ARCANA: Sequence[TarotCard] = (
+    TarotCard("The Fool", ("beginnings", "spontaneity", "faith"), "A leap into the unknown invites sacred trust."),
+    TarotCard("The Magician", ("manifestation", "skill", "willpower"), "You already possess the tools required to shape this moment."),
+    TarotCard("The High Priestess", ("intuition", "mystery", "inner voice"), "Listen for the whispers beneath surface logic."),
+    TarotCard("The Empress", ("fertility", "sensuality", "abundance"), "Nurture your ideas the way you would a flourishing garden."),
+    TarotCard("The Emperor", ("structure", "authority", "stability"), "Disciplined action turns inspiration into legacy."),
+    TarotCard("The Hierophant", ("tradition", "wisdom", "mentorship"), "Ritual and shared wisdom anchor your next steps."),
+    TarotCard("The Lovers", ("alignment", "connection", "values"), "Choose what mirrors your heart's deepest truth."),
+    TarotCard("The Chariot", ("determination", "focus", "momentum"), "Harness contrasting forces to drive forward with grace."),
+    TarotCard("Strength", ("courage", "compassion", "resilience"), "Gentle strength outshines brute force now."),
+    TarotCard("The Hermit", ("solitude", "searching", "inner guidance"), "Illuminate the path by honoring reflective pauses."),
+    TarotCard("Wheel of Fortune", ("cycles", "destiny", "turning point"), "Change is the only constant—pivot with intention."),
+    TarotCard("Justice", ("equilibrium", "truth", "accountability"), "Seek balance by aligning actions with integrity."),
+    TarotCard("The Hanged One", ("surrender", "perspective", "pause"), "Stillness births the revelation you seek."),
+    TarotCard("Death", ("release", "transformation", "rebirth"), "Letting go clears space for extraordinary renewal."),
+    TarotCard("Temperance", ("alchemy", "moderation", "purpose"), "Blend disparate pieces of your life into a cohesive whole."),
+    TarotCard("The Devil", ("shadow", "attachment", "awakening"), "Liberation arrives when you name the chains you carry."),
+    TarotCard("The Tower", ("revelation", "upheaval", "liberation"), "Radical truth dismantles what was never stable."),
+    TarotCard("The Star", ("hope", "healing", "inspiration"), "Your vulnerability is a lighthouse for others."),
+    TarotCard("The Moon", ("dreams", "intuition", "subconscious"), "Honor cyclical emotions—they are sacred navigation tools."),
+    TarotCard("The Sun", ("vitality", "joy", "radiance"), "Your authenticity is magnetic—let it shine freely."),
+    TarotCard("Judgement", ("awakening", "forgiveness", "purpose"), "Answer the call that won't stop echoing in your soul."),
+    TarotCard("The World", ("completion", "integration", "wholeness"), "Celebrate how far you've traveled and claim the next horizon."),
+)
+
+
+def _join_keywords(keywords: Iterable[str]) -> str:
+    keywords = tuple(keywords)
+    if not keywords:
+        return ""
+    if len(keywords) == 1:
+        return keywords[0]
+    return ", ".join(keywords[:-1]) + f", and {keywords[-1]}"

--- a/tarot_teller/user.py
+++ b/tarot_teller/user.py
@@ -1,0 +1,74 @@
+"""Utilities for collecting and representing TarotTeller user data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+
+
+@dataclass
+class UserProfile:
+    """Container describing the person receiving the reading."""
+
+    name: str
+    birthdate: date
+    favorite_color: str
+    intention: str | None = None
+
+
+def _prompt(prompt: str) -> str:
+    """Wrapper around :func:`input` to make testing easier."""
+
+    return input(prompt)
+
+
+def collect_user_profile() -> UserProfile:
+    """Interactively collect details for a new :class:`UserProfile`."""
+
+    name = _prompt("What name should I use for your reading? ").strip()
+    while not name:
+        print("I want this to feel personal—please share at least a first name.")
+        name = _prompt("What name should I use for your reading? ").strip()
+
+    birthdate = _prompt_for_birthdate()
+
+    favorite_color = _prompt("What color resonates with you today? ").strip()
+    while not favorite_color:
+        print("Every hue carries symbolism. Choose the color calling to you right now.")
+        favorite_color = _prompt("What color resonates with you today? ").strip()
+
+    intention = _prompt(
+        "Do you have a question, goal, or intention you'd like this reading to explore?\n"
+        "(Press enter to skip if you'd prefer a general reading.)\n> "
+    ).strip()
+
+    return UserProfile(
+        name=name,
+        birthdate=birthdate,
+        favorite_color=favorite_color,
+        intention=intention or None,
+    )
+
+
+def _prompt_for_birthdate() -> date:
+    """Ask for and validate a birthdate."""
+
+    help_text = (
+        "Please share your date of birth using the ISO format YYYY-MM-DD."
+        " This helps me calculate astrological influences accurately."
+    )
+
+    while True:
+        raw = _prompt("When were you born? (YYYY-MM-DD) ").strip()
+        try:
+            parsed = datetime.strptime(raw, "%Y-%m-%d").date()
+        except ValueError:
+            print("I wasn't able to understand that date.")
+            print(help_text)
+            continue
+
+        if parsed > date.today():
+            print("I sense a future birthdate—please provide the actual date you arrived.")
+            continue
+
+        return parsed

--- a/tests/test_astrology.py
+++ b/tests/test_astrology.py
@@ -1,0 +1,14 @@
+from datetime import date
+
+from tarot_teller.astrology import chinese_zodiac_for, western_zodiac_for
+
+
+def test_western_zodiac_boundaries():
+    assert western_zodiac_for(date(1990, 3, 21)).sign == "Aries"
+    assert western_zodiac_for(date(1990, 4, 19)).sign == "Aries"
+    assert western_zodiac_for(date(1990, 4, 20)).sign == "Taurus"
+
+
+def test_chinese_zodiac_cycle():
+    assert chinese_zodiac_for(date(1996, 7, 12)).animal == "Rat"
+    assert chinese_zodiac_for(date(1997, 7, 12)).animal == "Ox"

--- a/tests/test_native_american.py
+++ b/tests/test_native_american.py
@@ -1,0 +1,11 @@
+from datetime import date
+
+from tarot_teller.native_american import totem_for
+
+
+def test_totem_wraparound():
+    goose = totem_for(date(1990, 1, 15))
+    otter = totem_for(date(1990, 1, 25))
+
+    assert goose.totem == "Goose"
+    assert otter.totem == "Otter"

--- a/tests/test_numerology.py
+++ b/tests/test_numerology.py
@@ -1,0 +1,12 @@
+from datetime import date
+
+from tarot_teller.numerology import chaldean_numerology_for
+
+
+def test_numerology_reduction_and_breakdown():
+    insight = chaldean_numerology_for("Ada Lovelace", date(1815, 12, 10))
+    assert insight.name_number in {1, 2, 3, 4, 5, 6, 7, 8, 11, 22}
+    # Ensure breakdown only contains recognized characters
+    assert all(char.isalpha() for char, _ in insight.name_breakdown)
+    assert sum(value for _, value in insight.name_breakdown) >= insight.name_number
+    assert "name number" in insight.summary.lower()

--- a/tests/test_reading.py
+++ b/tests/test_reading.py
@@ -1,0 +1,23 @@
+from datetime import date
+import random
+
+from tarot_teller.reading import craft_full_reading
+from tarot_teller.user import UserProfile
+
+
+def test_full_reading_contains_sections():
+    user = UserProfile(
+        name="Test Seeker",
+        birthdate=date(1990, 7, 5),
+        favorite_color="blue",
+        intention="clarity about career",
+    )
+    reading = craft_full_reading(user, rng=random.Random(123))
+    rendered = reading.render()
+
+    assert "Celestial Alignments" in rendered
+    assert "Medicine Wheel Guidance" in rendered
+    assert "Chaldean Numerology" in rendered
+    assert "Three-Card Tarot Spread" in rendered
+    assert "Integrated Message" in rendered
+    assert user.name in rendered

--- a/tests/test_tarot.py
+++ b/tests/test_tarot.py
@@ -1,0 +1,16 @@
+import random
+
+from tarot_teller.tarot import draw_three_card_spread
+
+
+def test_three_card_spread_is_deterministic_with_seed():
+    rng = random.Random(42)
+    reading = draw_three_card_spread(rng)
+    cards = tuple(entry.card.name for entry in reading.spread)
+    assert len(cards) == 3
+    assert len(set(cards)) == 3
+    assert cards == (
+        "Judgement",
+        "The Empress",
+        "The Fool",
+    )


### PR DESCRIPTION
## Summary
- build a modular TarotTeller package that collects seeker details and orchestrates a multi-tradition reading
- add astrology, numerology, native medicine wheel, and tarot modules with rich narrative output
- provide pytest coverage and documentation for running the CLI and validating behaviour

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d12c2e1c1c832c95bd99b088de199f