### PR TITLE
Expand TarotTeller into full tarot reading toolkit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,76 @@
 # TarotTeller
+
+TarotTeller is a feature-rich tarot reading toolkit.  It bundles a complete deck,
+meaningful spreads, and a friendly command line interface for exploring the
+cards.  The library is equally at home in scripts thanks to its expressive Python
+API.
+
+## Features
+
+- Complete 78 card deck with upright and reversed keywords and descriptions.
+- Programmatically generated minor arcana ensure consistent language across suits.
+- Built-in spreads, including a single card pull, three card story, and Celtic Cross.
+- Command line tools for listing cards, viewing rich card profiles, and drawing
+  readings with optional deterministic seeding.
+- Well-documented Python API suited for automation or experimentation.
+
+## Installation
+
+The project uses a modern `pyproject.toml` configuration.  Install it in editable
+mode to try it locally:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+## Command line usage
+
+```
+usage: tarotteller [-h] {list,info,draw} ...
+```
+
+Examples:
+
+- List the first few major arcana cards:
+
+  ```bash
+  tarotteller list --arcana major --limit 5
+  ```
+
+- Draw a quick three card reading without reversals:
+
+  ```bash
+  tarotteller draw --spread three_card --no-reversed
+  ```
+
+- Pull two cards with deterministic order and orientation:
+
+  ```bash
+  tarotteller draw --cards 2 --seed 7 --orientation-seed 11
+  ```
+
+## Programmatic usage
+
+Use the Python API for more control over spreads and cards:
+
+```python
+from tarotteller import TarotDeck, draw_spread
+
+deck = TarotDeck()
+deck.seed(42)
+deck.reset(shuffle=True)
+reading = draw_spread(deck, "three_card", rng=99)
+
+for placement in reading.placements:
+    print(placement.position.title, placement.card.card.name, placement.card.orientation)
+```
+
+## Development
+
+Run the automated tests with `pytest`:
+
+```bash
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=67", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tarotteller"
+version = "0.1.0"
+description = "A feature-rich tarot reading toolkit with CLI utilities and spread helpers."
+readme = "README.md"
+authors = [{name = "Tarot Teller Maintainers"}]
+license = {text = "MIT"}
+requires-python = ">=3.9"
+dependencies = []
+
+[project.scripts]
+tarotteller = "tarotteller.cli:main"
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+addopts = "-ra"

--- a/src/tarotteller/__init__.py
+++ b/src/tarotteller/__init__.py
@@ -1,0 +1,14 @@
+"""TarotTeller package exposing tarot deck utilities."""
+
+from .deck import DrawnCard, TarotCard, TarotDeck
+from .spreads import SPREADS, draw_spread
+
+__all__ = [
+    "DrawnCard",
+    "TarotCard",
+    "TarotDeck",
+    "SPREADS",
+    "draw_spread",
+]
+
+__version__ = "0.1.0"

--- a/src/tarotteller/data.py
+++ b/src/tarotteller/data.py
@@ -1,0 +1,367 @@
+"""Static data definitions for tarot cards used by :mod:`tarotteller`.
+
+The module exposes rich metadata for both the major and minor arcana.  The
+minor arcana data is generated programmatically from suit and rank descriptors
+so that the resulting cards feel cohesive while keeping the definitions easy to
+maintain.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+
+MAJOR_ARCANA: List[Dict[str, object]] = [
+    {
+        "arcana": "major",
+        "number": 0,
+        "name": "The Fool",
+        "keywords": ["beginnings", "adventure", "innocence"],
+        "reversed_keywords": ["hesitation", "risk", "recklessness"],
+        "description": "A leap of faith invites new experiences and personal growth when embraced with curiosity.",
+    },
+    {
+        "arcana": "major",
+        "number": 1,
+        "name": "The Magician",
+        "keywords": ["manifestation", "resourcefulness", "power"],
+        "reversed_keywords": ["untapped potential", "manipulation", "distraction"],
+        "description": "Focused intention turns ideas into reality; align your skills with your will to create change.",
+    },
+    {
+        "arcana": "major",
+        "number": 2,
+        "name": "The High Priestess",
+        "keywords": ["intuition", "mystery", "stillness"],
+        "reversed_keywords": ["secrets", "disconnection", "doubt"],
+        "description": "Quiet reflection reveals hidden knowledge and invites trust in your inner wisdom.",
+    },
+    {
+        "arcana": "major",
+        "number": 3,
+        "name": "The Empress",
+        "keywords": ["abundance", "nurturing", "fertility"],
+        "reversed_keywords": ["creative block", "dependence", "neglect"],
+        "description": "A season of growth rewards compassion, creativity, and tending to what you cherish most.",
+    },
+    {
+        "arcana": "major",
+        "number": 4,
+        "name": "The Emperor",
+        "keywords": ["structure", "authority", "stability"],
+        "reversed_keywords": ["control", "rigidity", "power struggles"],
+        "description": "Clear boundaries and deliberate leadership bring lasting security when used responsibly.",
+    },
+    {
+        "arcana": "major",
+        "number": 5,
+        "name": "The Hierophant",
+        "keywords": ["tradition", "wisdom", "mentorship"],
+        "reversed_keywords": ["rebellion", "dogma", "restriction"],
+        "description": "Seek guidance in shared knowledge and rituals, while remembering to keep them meaningful to you.",
+    },
+    {
+        "arcana": "major",
+        "number": 6,
+        "name": "The Lovers",
+        "keywords": ["connection", "values", "choice"],
+        "reversed_keywords": ["misalignment", "imbalance", "temptation"],
+        "description": "Relationships mirror your ideals; choose with integrity and honour your heart's truth.",
+    },
+    {
+        "arcana": "major",
+        "number": 7,
+        "name": "The Chariot",
+        "keywords": ["determination", "willpower", "momentum"],
+        "reversed_keywords": ["scattered energy", "aggression", "lack of direction"],
+        "description": "Harness discipline to steer conflicting forces toward a shared destination and triumph.",
+    },
+    {
+        "arcana": "major",
+        "number": 8,
+        "name": "Strength",
+        "keywords": ["courage", "compassion", "resilience"],
+        "reversed_keywords": ["self-doubt", "fear", "raw emotion"],
+        "description": "Gentle persistence and empathy tame fears more effectively than force alone ever could.",
+    },
+    {
+        "arcana": "major",
+        "number": 9,
+        "name": "The Hermit",
+        "keywords": ["introspection", "solitude", "wisdom"],
+        "reversed_keywords": ["withdrawal", "loneliness", "isolation"],
+        "description": "Retreat to listen to your own voice and carry its lantern back to light the path forward.",
+    },
+    {
+        "arcana": "major",
+        "number": 10,
+        "name": "Wheel of Fortune",
+        "keywords": ["cycles", "destiny", "turning point"],
+        "reversed_keywords": ["resistance", "unexpected setbacks", "control"],
+        "description": "Life turns in constant motion; adapt with grace and you can ride the wave of change.",
+    },
+    {
+        "arcana": "major",
+        "number": 11,
+        "name": "Justice",
+        "keywords": ["fairness", "truth", "accountability"],
+        "reversed_keywords": ["bias", "dishonesty", "avoidance"],
+        "description": "Decisions carry consequence—act with honesty and weigh all sides before moving ahead.",
+    },
+    {
+        "arcana": "major",
+        "number": 12,
+        "name": "The Hanged Man",
+        "keywords": ["surrender", "new perspective", "pause"],
+        "reversed_keywords": ["stalling", "resistance", "martyrdom"],
+        "description": "Letting go of control clears space for insight and transforms limbo into awakening.",
+    },
+    {
+        "arcana": "major",
+        "number": 13,
+        "name": "Death",
+        "keywords": ["transformation", "endings", "renewal"],
+        "reversed_keywords": ["stagnation", "fear of change", "clinging"],
+        "description": "Release what has reached its conclusion to welcome a revitalising chapter.",
+    },
+    {
+        "arcana": "major",
+        "number": 14,
+        "name": "Temperance",
+        "keywords": ["balance", "moderation", "alchemy"],
+        "reversed_keywords": ["excess", "imbalance", "restlessness"],
+        "description": "Blend opposing elements thoughtfully to craft a harmonious and sustainable rhythm.",
+    },
+    {
+        "arcana": "major",
+        "number": 15,
+        "name": "The Devil",
+        "keywords": ["shadow", "bondage", "materialism"],
+        "reversed_keywords": ["liberation", "awareness", "detachment"],
+        "description": "Notice the chains you accept; conscious choice can dissolve limiting patterns.",
+    },
+    {
+        "arcana": "major",
+        "number": 16,
+        "name": "The Tower",
+        "keywords": ["upheaval", "revelation", "breakthrough"],
+        "reversed_keywords": ["averted disaster", "denial", "fear of change"],
+        "description": "Sudden clarity dismantles unstable foundations so that stronger truth can emerge.",
+    },
+    {
+        "arcana": "major",
+        "number": 17,
+        "name": "The Star",
+        "keywords": ["hope", "healing", "guidance"],
+        "reversed_keywords": ["discouragement", "doubt", "over-giving"],
+        "description": "A calm beacon reminds you to replenish your spirit and trust that renewal is near.",
+    },
+    {
+        "arcana": "major",
+        "number": 18,
+        "name": "The Moon",
+        "keywords": ["intuition", "dreams", "subconscious"],
+        "reversed_keywords": ["confusion", "anxiety", "revelation"],
+        "description": "Shadows distort the path—listen to subtle cues and move slowly until truth surfaces.",
+    },
+    {
+        "arcana": "major",
+        "number": 19,
+        "name": "The Sun",
+        "keywords": ["vitality", "success", "joy"],
+        "reversed_keywords": ["delayed gratification", "overconfidence", "temporary cloudiness"],
+        "description": "Warmth, clarity, and celebration radiate outward when you act from authentic confidence.",
+    },
+    {
+        "arcana": "major",
+        "number": 20,
+        "name": "Judgement",
+        "keywords": ["rebirth", "reckoning", "awakening"],
+        "reversed_keywords": ["self-doubt", "avoidance", "stagnation"],
+        "description": "Answer the call to evolve; honest reflection frees you to step into purpose.",
+    },
+    {
+        "arcana": "major",
+        "number": 21,
+        "name": "The World",
+        "keywords": ["completion", "integration", "wholeness"],
+        "reversed_keywords": ["loose ends", "incompletion", "delays"],
+        "description": "Celebrate milestones and recognise the mastery earned through the journey's cycle.",
+    },
+]
+
+
+SUITS: Dict[str, Dict[str, object]] = {
+    "Wands": {
+        "element": "Fire",
+        "keywords": ["creativity", "ambition", "willpower"],
+        "reversed_keywords": ["burnout", "impulsiveness", "frustration"],
+        "themes": "passion, invention, and the spark that propels ideas into action",
+    },
+    "Cups": {
+        "element": "Water",
+        "keywords": ["emotion", "relationships", "intuition"],
+        "reversed_keywords": ["emotional drain", "codependence", "suppression"],
+        "themes": "feelings, empathy, spiritual connection, and the flow between hearts",
+    },
+    "Swords": {
+        "element": "Air",
+        "keywords": ["thought", "communication", "clarity"],
+        "reversed_keywords": ["conflict", "overthinking", "anxiety"],
+        "themes": "intellect, conflict, analysis, and the pursuit of clear truth",
+    },
+    "Pentacles": {
+        "element": "Earth",
+        "keywords": ["stability", "resources", "practicality"],
+        "reversed_keywords": ["insecurity", "materialism", "stagnation"],
+        "themes": "work, health, and the tangible results of long-term stewardship",
+    },
+}
+
+
+RANKS: List[Dict[str, object]] = [
+    {
+        "name": "Ace",
+        "number": 1,
+        "keywords": ["beginnings", "potential", "spark"],
+        "reversed_keywords": ["blocked start", "misuse", "uncertainty"],
+        "description": "A seed of opportunity arrives, eager to grow if nurtured with intention.",
+    },
+    {
+        "name": "Two",
+        "number": 2,
+        "keywords": ["balance", "duality", "choice"],
+        "reversed_keywords": ["imbalance", "indecision", "stalemate"],
+        "description": "Two forces seek harmony, calling for cooperation and mindful decision making.",
+    },
+    {
+        "name": "Three",
+        "number": 3,
+        "keywords": ["expansion", "collaboration", "growth"],
+        "reversed_keywords": ["delay", "misalignment", "frustration"],
+        "description": "Community and planning turn early efforts into meaningful progress.",
+    },
+    {
+        "name": "Four",
+        "number": 4,
+        "keywords": ["stability", "foundation", "containment"],
+        "reversed_keywords": ["stagnation", "restlessness", "rigidity"],
+        "description": "Structures provide security, yet must be refreshed to avoid complacency.",
+    },
+    {
+        "name": "Five",
+        "number": 5,
+        "keywords": ["challenge", "disruption", "growth"],
+        "reversed_keywords": ["avoidance", "lingering conflict", "recovery"],
+        "description": "Tension invites adaptation, forging resilience through discomfort.",
+    },
+    {
+        "name": "Six",
+        "number": 6,
+        "keywords": ["harmony", "support", "reconciliation"],
+        "reversed_keywords": ["one-sidedness", "stagnation", "nostalgia"],
+        "description": "Cooperation and shared care restore balance and goodwill.",
+    },
+    {
+        "name": "Seven",
+        "number": 7,
+        "keywords": ["assessment", "faith", "strategy"],
+        "reversed_keywords": ["doubt", "impulsiveness", "avoidance"],
+        "description": "Patience and evaluation clarify the next stage of effort.",
+    },
+    {
+        "name": "Eight",
+        "number": 8,
+        "keywords": ["movement", "mastery", "dedication"],
+        "reversed_keywords": ["distraction", "perfectionism", "stalling"],
+        "description": "Momentum builds through focused commitment and steady practice.",
+    },
+    {
+        "name": "Nine",
+        "number": 9,
+        "keywords": ["culmination", "self-reliance", "integration"],
+        "reversed_keywords": ["overwhelm", "isolation", "impatience"],
+        "description": "Self-awareness and discipline prepare you for the final stretch.",
+    },
+    {
+        "name": "Ten",
+        "number": 10,
+        "keywords": ["completion", "legacy", "transition"],
+        "reversed_keywords": ["burden", "instability", "overextension"],
+        "description": "A chapter resolves, offering perspective on what was gained and what comes next.",
+    },
+    {
+        "name": "Page",
+        "number": 11,
+        "keywords": ["curiosity", "study", "playfulness"],
+        "reversed_keywords": ["naivety", "inconsistency", "immaturity"],
+        "description": "Messenger energy arrives—stay open to learning and exploring without judgment.",
+    },
+    {
+        "name": "Knight",
+        "number": 12,
+        "keywords": ["pursuit", "momentum", "mission"],
+        "reversed_keywords": ["recklessness", "scattered focus", "frustration"],
+        "description": "Bold action advances your goals when tempered with awareness of the impact.",
+    },
+    {
+        "name": "Queen",
+        "number": 13,
+        "keywords": ["maturity", "nurturing", "magnetism"],
+        "reversed_keywords": ["smothering", "insecurity", "withdrawal"],
+        "description": "Power softens into generosity, tending to others while upholding healthy boundaries.",
+    },
+    {
+        "name": "King",
+        "number": 14,
+        "keywords": ["command", "responsibility", "vision"],
+        "reversed_keywords": ["domination", "rigidity", "overbearing"],
+        "description": "Leadership is proven through integrity and consistent stewardship of resources.",
+    },
+]
+
+
+def build_minor_arcana() -> List[Dict[str, object]]:
+    """Create the 56 cards that make up the minor arcana.
+
+    The returned dictionaries mirror the structure used for the major arcana,
+    but also include ``suit`` and ``rank`` metadata so that callers can filter
+    or present the cards as needed.
+    """
+
+    cards: List[Dict[str, object]] = []
+    for suit_name, suit in SUITS.items():
+        suit_keywords = list(suit["keywords"])
+        suit_reversed = list(suit["reversed_keywords"])
+        for rank in RANKS:
+            name = f"{rank['name']} of {suit_name}"
+            keywords = sorted(set(rank["keywords"] + suit_keywords))
+            reversed_keywords = sorted(set(rank["reversed_keywords"] + suit_reversed))
+            description = (
+                f"{rank['description']} Expressed through the realm of {suit_name.lower()}, "
+                f"it highlights {suit['themes']}."
+            )
+            cards.append(
+                {
+                    "arcana": "minor",
+                    "number": rank["number"],
+                    "name": name,
+                    "suit": suit_name,
+                    "rank": rank["name"],
+                    "keywords": keywords,
+                    "reversed_keywords": reversed_keywords,
+                    "description": description,
+                    "element": suit["element"],
+                }
+            )
+    return cards
+
+
+MINOR_ARCANA: List[Dict[str, object]] = build_minor_arcana()
+
+
+def iter_all_cards() -> Iterable[Dict[str, object]]:
+    """Yield dictionaries for each of the 78 tarot cards."""
+
+    yield from MAJOR_ARCANA
+    yield from MINOR_ARCANA

--- a/src/tarotteller/deck.py
+++ b/src/tarotteller/deck.py
@@ -1,0 +1,187 @@
+"""Core tarot deck logic for TarotTeller."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Iterable, Iterator, List, Optional, Sequence
+
+from . import data
+
+
+@dataclass(frozen=True)
+class TarotCard:
+    """Represents a single tarot card with upright and reversed meanings."""
+
+    name: str
+    arcana: str
+    number: int
+    keywords: Sequence[str]
+    reversed_keywords: Sequence[str]
+    description: str
+    suit: Optional[str] = None
+    rank: Optional[str] = None
+    element: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, payload: dict) -> "TarotCard":
+        """Create a :class:`TarotCard` from a dictionary entry."""
+
+        return cls(
+            name=str(payload["name"]),
+            arcana=str(payload["arcana"]),
+            number=int(payload["number"]),
+            keywords=tuple(payload["keywords"]),
+            reversed_keywords=tuple(payload["reversed_keywords"]),
+            description=str(payload["description"]),
+            suit=payload.get("suit"),
+            rank=payload.get("rank"),
+            element=payload.get("element"),
+        )
+
+    def matches(self, query: str) -> bool:
+        """Return ``True`` if ``query`` corresponds to this card's name.
+
+        The comparison is case-insensitive and ignores superfluous whitespace.
+        """
+
+        normalized = " ".join(query.strip().lower().split())
+        return normalized == " ".join(self.name.lower().split())
+
+
+@dataclass(frozen=True)
+class DrawnCard:
+    """A tarot card that has been drawn and oriented."""
+
+    card: TarotCard
+    is_reversed: bool = False
+
+    @property
+    def orientation(self) -> str:
+        return "reversed" if self.is_reversed else "upright"
+
+    @property
+    def keywords(self) -> Sequence[str]:
+        return self.card.reversed_keywords if self.is_reversed else self.card.keywords
+
+    @property
+    def meaning(self) -> str:
+        if self.is_reversed:
+            return (
+                f"Reversed, {self.card.name} highlights themes of "
+                f"{', '.join(self.card.reversed_keywords)}."
+            )
+        return (
+            f"Upright, {self.card.name} focuses on {', '.join(self.card.keywords)}."
+        )
+
+
+class TarotDeck:
+    """A full 78-card tarot deck with helpful drawing helpers."""
+
+    def __init__(self, *, rng: Optional[random.Random] = None) -> None:
+        self._rng = rng or random.Random()
+        self._cards: List[TarotCard] = [
+            TarotCard.from_dict(entry) for entry in data.iter_all_cards()
+        ]
+        self._stack: List[TarotCard] = []
+        self.reset(shuffle=True)
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self._stack)
+
+    def __iter__(self) -> Iterator[TarotCard]:  # pragma: no cover - simple passthrough
+        return iter(self._stack)
+
+    @property
+    def all_cards(self) -> Sequence[TarotCard]:
+        """All cards in their canonical order (major followed by minor)."""
+
+        return tuple(self._cards)
+
+    def seed(self, seed_value: Optional[int]) -> None:
+        """Seed the internal random number generator for deterministic draws."""
+
+        self._rng.seed(seed_value)
+
+    def reset(self, *, shuffle: bool = False) -> None:
+        """Restore the deck to its full size, optionally shuffling."""
+
+        self._stack = list(self._cards)
+        if shuffle:
+            self.shuffle()
+
+    def shuffle(self) -> None:
+        """Shuffle the deck in-place using the deck's RNG."""
+
+        self._rng.shuffle(self._stack)
+
+    def draw(
+        self,
+        count: int = 1,
+        *,
+        allow_reversed: bool = True,
+        rng: Optional[random.Random] = None,
+    ) -> List[DrawnCard]:
+        """Draw ``count`` cards from the deck.
+
+        :param count: Number of cards to draw.
+        :param allow_reversed: Whether cards may appear reversed.
+        :param rng: Optional custom RNG for orientation decisions.
+        :raises ValueError: If the deck does not contain enough cards.
+        """
+
+        if count < 1:
+            raise ValueError("count must be at least 1")
+        if count > len(self._stack):
+            raise ValueError("Not enough cards remaining in the deck")
+
+        orientation_rng = rng or self._rng
+        drawn_cards: List[DrawnCard] = []
+        for _ in range(count):
+            card = self._stack.pop(0)
+            is_reversed = allow_reversed and bool(orientation_rng.getrandbits(1))
+            drawn_cards.append(DrawnCard(card=card, is_reversed=is_reversed))
+        return drawn_cards
+
+    def get_card(self, query: str) -> Optional[TarotCard]:
+        """Look up a card by name, returning ``None`` if it is not found."""
+
+        for card in self._cards:
+            if card.matches(query):
+                return card
+        return None
+
+    def list_cards(
+        self,
+        *,
+        arcana: Optional[str] = None,
+        suit: Optional[str] = None,
+    ) -> Iterable[TarotCard]:
+        """Yield cards filtered by arcana and suit criteria."""
+
+        for card in self._cards:
+            if arcana and card.arcana.lower() != arcana.lower():
+                continue
+            if suit and (card.suit or "").lower() != suit.lower():
+                continue
+            yield card
+
+
+def format_card(card: TarotCard) -> str:
+    """Return a richly formatted multi-line string for ``card``."""
+
+    lines = [card.name]
+    lines.append("-" * len(card.name))
+    lines.append(f"Arcana : {card.arcana.title()}")
+    if card.suit:
+        lines.append(f"Suit   : {card.suit} (element of {card.element})")
+        lines.append(f"Rank   : {card.rank}")
+    lines.append(f"Number : {card.number}")
+    lines.append(f"Keywords (upright) : {', '.join(card.keywords)}")
+    lines.append(
+        f"Keywords (reversed): {', '.join(card.reversed_keywords)}"
+    )
+    lines.append("")
+    lines.append(card.description)
+    return "\n".join(lines)

--- a/src/tarotteller/spreads.py
+++ b/src/tarotteller/spreads.py
@@ -1,0 +1,151 @@
+"""Spread definitions and helper utilities for tarot readings."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from .deck import DrawnCard, TarotDeck
+
+
+@dataclass(frozen=True)
+class SpreadPosition:
+    """Metadata describing a slot within a tarot spread."""
+
+    index: int
+    title: str
+    prompt: str
+
+
+@dataclass(frozen=True)
+class Spread:
+    """A tarot spread describing how many cards to draw and their roles."""
+
+    name: str
+    description: str
+    positions: List[SpreadPosition]
+
+    @property
+    def size(self) -> int:
+        return len(self.positions)
+
+
+@dataclass(frozen=True)
+class SpreadPlacement:
+    """A drawn card paired with its position in the spread."""
+
+    position: SpreadPosition
+    card: DrawnCard
+
+
+@dataclass(frozen=True)
+class SpreadReading:
+    """The final result of evaluating a spread with a deck."""
+
+    spread: Spread
+    placements: List[SpreadPlacement]
+
+    def as_text(self) -> str:
+        """Render the spread in a human-readable block of text."""
+
+        lines = [f"Spread: {self.spread.name}", self.spread.description, ""]
+        for placement in self.placements:
+            header = f"{placement.position.index}. {placement.position.title}"
+            lines.append(header)
+            lines.append("-" * len(header))
+            lines.append(placement.position.prompt)
+            lines.append(
+                f"Card: {placement.card.card.name} ({placement.card.orientation})"
+            )
+            lines.append(placement.card.meaning)
+            lines.append("")
+        return "\n".join(lines).strip()
+
+
+SPREADS: Dict[str, Spread] = {
+    "single": Spread(
+        name="Single Card Insight",
+        description="A straightforward pull for guidance on the present moment.",
+        positions=[
+            SpreadPosition(
+                index=1,
+                title="Message",
+                prompt="What energy is most important to understand right now?",
+            )
+        ],
+    ),
+    "three_card": Spread(
+        name="Three Card Story",
+        description="A balanced Past / Present / Future reading.",
+        positions=[
+            SpreadPosition(
+                index=1,
+                title="Past",
+                prompt="What history is influencing the situation?",
+            ),
+            SpreadPosition(
+                index=2,
+                title="Present",
+                prompt="Where does the situation currently stand?",
+            ),
+            SpreadPosition(
+                index=3,
+                title="Future",
+                prompt="What trajectory is developing from current momentum?",
+            ),
+        ],
+    ),
+    "celtic_cross": Spread(
+        name="Celtic Cross",
+        description="A classic ten-card map of challenges, influences, and outcomes.",
+        positions=[
+            SpreadPosition(1, "Significator", "The heart of the matter at hand."),
+            SpreadPosition(2, "Crossing", "The energy currently challenging the significator."),
+            SpreadPosition(3, "Foundation", "Deep roots, subconscious drives, or the distant past."),
+            SpreadPosition(4, "Recent Past", "Events that have shaped the present."),
+            SpreadPosition(5, "Crown", "Conscious focus, goals, or potential."),
+            SpreadPosition(6, "Near Future", "What is entering the story soon."),
+            SpreadPosition(7, "Self", "How you view yourself or your role."),
+            SpreadPosition(8, "Environment", "External influences and relationships."),
+            SpreadPosition(9, "Hopes & Fears", "The vulnerabilities colouring perception."),
+            SpreadPosition(10, "Outcome", "Likely direction if the current energy continues."),
+        ],
+    ),
+}
+
+
+def draw_spread(
+    deck: TarotDeck,
+    spread_name: str,
+    *,
+    allow_reversed: bool = True,
+    rng: Optional[int] = None,
+) -> SpreadReading:
+    """Draw cards from ``deck`` according to ``spread_name``.
+
+    :param deck: The :class:`~tarotteller.deck.TarotDeck` to draw from.  Cards are
+        removed from the deck's current stack.
+    :param spread_name: Key in :data:`SPREADS`.  A :class:`KeyError` is raised if
+        the spread is unknown.
+    :param allow_reversed: Whether reversals are permitted in the draw.
+    :param rng: Optional seed for deterministic orientation results.
+    """
+
+    spread = SPREADS[spread_name]
+    orientation_rng: Optional[random.Random]
+    if rng is None:
+        orientation_rng = None
+    else:
+        orientation_rng = random.Random(rng)
+
+    drawn_cards = deck.draw(
+        spread.size,
+        allow_reversed=allow_reversed,
+        rng=orientation_rng,
+    )
+    placements = [
+        SpreadPlacement(position=position, card=card)
+        for position, card in zip(spread.positions, drawn_cards)
+    ]
+    return SpreadReading(spread=spread, placements=placements)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,36 @@
+from tarotteller import cli
+
+
+def run_cli(args):
+    return cli.main(args)
+
+
+def test_cli_list_major(capsys):
+    exit_code = run_cli(["list", "--arcana", "major", "--limit", "3"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Cards in deck" in captured.out
+    assert "The Fool" in captured.out
+
+
+def test_cli_info(capsys):
+    exit_code = run_cli(["info", "The Magician"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "The Magician" in captured.out
+    assert "Arcana : Major" in captured.out
+
+
+def test_cli_draw_cards(capsys):
+    exit_code = run_cli([
+        "draw",
+        "--cards",
+        "2",
+        "--seed",
+        "5",
+        "--no-reversed",
+    ])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Card 1:" in captured.out
+    assert "(upright)" in captured.out

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -1,0 +1,33 @@
+from tarotteller.deck import TarotDeck
+
+
+def test_deck_contains_full_set():
+    deck = TarotDeck()
+    cards = deck.all_cards
+    assert len(cards) == 78
+    assert sum(1 for card in cards if card.arcana == "major") == 22
+    assert sum(1 for card in cards if card.arcana == "minor") == 56
+    assert len({card.name for card in cards}) == 78
+
+
+def test_get_card_case_insensitive():
+    deck = TarotDeck()
+    card = deck.get_card(" the fool ")
+    assert card is not None
+    assert card.name == "The Fool"
+
+
+def test_draw_reduces_stack():
+    deck = TarotDeck()
+    original_remaining = len(deck)
+    drawn = deck.draw(3)
+    assert len(drawn) == 3
+    assert len(deck) == original_remaining - 3
+
+
+def test_draw_without_reversals():
+    deck = TarotDeck()
+    deck.seed(123)
+    deck.reset(shuffle=True)
+    drawn = deck.draw(5, allow_reversed=False)
+    assert all(not card.is_reversed for card in drawn)

--- a/tests/test_spreads.py
+++ b/tests/test_spreads.py
@@ -1,0 +1,24 @@
+from tarotteller.deck import TarotDeck
+from tarotteller.spreads import SPREADS, draw_spread
+
+
+def test_spread_definitions_have_expected_sizes():
+    assert SPREADS["single"].size == 1
+    assert SPREADS["three_card"].size == 3
+    assert SPREADS["celtic_cross"].size == 10
+
+
+def test_draw_spread_produces_reading():
+    deck = TarotDeck()
+    deck.seed(99)
+    deck.reset(shuffle=True)
+    reading = draw_spread(deck, "three_card", rng=21)
+    assert len(reading.placements) == 3
+    assert reading.placements[0].position.title == "Past"
+    assert reading.placements[-1].position.title == "Future"
+    # Orientation seed deterministically sets reversed states
+    orientations = [placement.card.orientation for placement in reading.placements]
+    assert orientations == ["upright", "upright", "reversed"]
+    text = reading.as_text()
+    assert "Three Card Story" in text
+    assert "Past" in text and "Future" in text


### PR DESCRIPTION
## Summary
- add a Python package providing tarot deck data, spread helpers, and a CLI entry point
- generate the minor arcana programmatically and expose reusable spread utilities
- document installation and usage while adding pytest coverage for the deck, spreads, and CLI

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1553897b8832caba1c093052ff4eb