### PR TITLE
Enhance tarot readings with richer narratives

### DIFF
--- a/src/tarotteller/cli.py
+++ b/src/tarotteller/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+import textwrap
 from typing import Iterable, List, Optional
 
 from .deck import TarotCard, TarotDeck, format_card
@@ -14,6 +15,13 @@ def _print_cards(cards: Iterable[TarotCard]) -> None:
     for card in cards:
         suit = f" ({card.suit})" if card.suit else ""
         print(f"- {card.name}{suit}")
+
+
+def _wrap_prompt(text: str) -> str:
+    wrapper = textwrap.TextWrapper(
+        width=72, initial_indent="   ", subsequent_indent="   "
+    )
+    return wrapper.fill(text)
 
 
 def cmd_list(deck: TarotDeck, args: argparse.Namespace) -> int:
@@ -43,10 +51,12 @@ def _format_simple_draw(reading: SpreadReading) -> str:
     lines: List[str] = []
     for placement in reading.placements:
         card = placement.card
+        prompt = _wrap_prompt(placement.position.prompt)
+        meaning = textwrap.indent(card.meaning, "   ")
         lines.append(
             f"{placement.position.index}. {card.card.name} ({card.orientation})\n"
-            f"   {placement.position.prompt}\n"
-            f"   {card.meaning}"
+            f"{prompt}\n"
+            f"{meaning}"
         )
     return "\n".join(lines)
 

--- a/src/tarotteller/deck.py
+++ b/src/tarotteller/deck.py
@@ -4,9 +4,31 @@ from __future__ import annotations
 
 import random
 from dataclasses import dataclass
+import textwrap
 from typing import Iterable, Iterator, List, Optional, Sequence
 
 from . import data
+
+
+_MEANING_WRAP_WIDTH = 72
+
+
+def _natural_join(words: Sequence[str]) -> str:
+    """Return a human-friendly comma separated list."""
+
+    if not words:
+        return ""
+    if len(words) == 1:
+        return words[0]
+    if len(words) == 2:
+        return f"{words[0]} and {words[1]}"
+    return f"{', '.join(words[:-1])}, and {words[-1]}"
+
+
+def _wrap_paragraph(text: str) -> str:
+    """Wrap ``text`` to the standard meaning width."""
+
+    return textwrap.fill(" ".join(text.split()), width=_MEANING_WRAP_WIDTH)
 
 
 @dataclass(frozen=True)
@@ -66,14 +88,31 @@ class DrawnCard:
 
     @property
     def meaning(self) -> str:
+        keywords = self.keywords
+        theme = _natural_join(keywords)
+
         if self.is_reversed:
-            return (
-                f"Reversed, {self.card.name} highlights themes of "
-                f"{', '.join(self.card.reversed_keywords)}."
+            opening = (
+                f"Reversed, {self.card.name} throws down a gauntlet around {theme}, "
+                "exposing pressure points you've been skirting."
             )
-        return (
-            f"Upright, {self.card.name} focuses on {', '.join(self.card.keywords)}."
-        )
+            closing = (
+                "Channel that disruption into fierce self-honesty, break the stale "
+                "pattern, and rebuild on your own terms."
+            )
+        else:
+            opening = (
+                f"Upright, {self.card.name} ignites {theme}, lighting a trail "
+                "you can charge down with conviction."
+            )
+            closing = (
+                "Ride that tailwind and take a bold step that matches the scale "
+                "of your ambition."
+            )
+
+        paragraphs = [opening, self.card.description, closing]
+        wrapped = [_wrap_paragraph(text) for text in paragraphs if text]
+        return "\n\n".join(wrapped)
 
 
 class TarotDeck:

--- a/src/tarotteller/spreads.py
+++ b/src/tarotteller/spreads.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import random
 from dataclasses import dataclass
+import textwrap
 from typing import Dict, List, Optional
 
 from .deck import DrawnCard, TarotDeck
@@ -54,11 +55,15 @@ class SpreadReading:
             header = f"{placement.position.index}. {placement.position.title}"
             lines.append(header)
             lines.append("-" * len(header))
-            lines.append(placement.position.prompt)
-            lines.append(
-                f"Card: {placement.card.card.name} ({placement.card.orientation})"
+            prompt = textwrap.fill(placement.position.prompt, width=72)
+            card_line = textwrap.fill(
+                f"Card: {placement.card.card.name} ({placement.card.orientation})",
+                width=72,
             )
-            lines.append(placement.card.meaning)
+            meaning = textwrap.indent(placement.card.meaning, "  ")
+            lines.append(prompt)
+            lines.append(card_line)
+            lines.append(meaning)
             lines.append("")
         return "\n".join(lines).strip()
 


### PR DESCRIPTION
## Summary
- amplify drawn card meanings with bold, multi-paragraph narratives while wrapping to a consistent width
- wrap prompts and meanings in CLI draw output so spread text stays within the card layout
- format detailed spread views with wrapped prompts, card lines, and indented meanings for cleaner readability

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5c333dcf8832c868c3f6e1b93147a