### PR TITLE
feat: add contextual interpretation engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,50 @@ Run the automated tests with `pytest`:
 ```bash
 pytest
 ```
+
+## Enhancement roadmap
+
+The current release draws exclusively on the static tarot metadata defined in
+`src/tarotteller/data.py`.  To move toward the "stronger readings" vision for
+TarotTeller, plan work in the following stages:
+
+### Immediate technical fixes
+
+- Replace any future bespoke astronomy routines with an industrial-grade
+  ephemeris source such as NASA/JPL's SPICE data services to ensure accurate
+  planetary positions.
+- Introduce transfer learning with a pre-trained language model (e.g., BERT or
+  GPT) and wrap it with natural language understanding so the app can parse
+  nuanced user prompts before generating readings.
+
+### Knowledge and reasoning upgrades
+
+- Design a comprehensive knowledge graph that captures detailed card meanings,
+  astrological correspondences, symbolism, and historical patterns.
+- Explore graph neural networks (GNNs) to reason over that graph, enabling the
+  engine to connect disparate archetypes during an interpretation.
+
+### System architecture improvements
+
+- Structure the platform as a pipeline: context analyzer → knowledge base → ML
+  engine → quality assurance → feedback loop.  Ensure each component exposes
+  clear interfaces and confidence scores so downstream checks can gate output.
+
+### Implementation highlights
+
+- Upgrade the ML layer with deep neural networks for generating interpretations,
+  multimodal learning that links card imagery to meanings, and probabilistic
+  models for better nuance.
+- Personalize readings by tracking user interaction history, applying
+  collaborative filtering, and experimenting with reinforcement learning to
+  adapt responses to individual preferences.
+- Reinforce quality by instituting multi-stage verification, adding GAN-based
+  polish for natural language, and automating accuracy tests across canonical
+  readings.
+
+### Metrics to monitor
+
+- Reading quality: user satisfaction, completion rates, return visits, and time
+  spent per session.
+- System health: coherence scores, accuracy against known interpretations,
+  processing time, and error rate reductions over successive releases.

--- a/src/tarotteller/context.py
+++ b/src/tarotteller/context.py
@@ -1,0 +1,100 @@
+"""Question analysis helpers for contextualised tarot readings."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List, Sequence
+
+from .knowledge import THEME_KEYWORDS
+
+_TIMEFRAME_KEYWORDS = {
+    "immediate": ("today", "right now", "currently", "in the moment"),
+    "short_term": ("soon", "this week", "next week", "this month", "near future"),
+    "long_term": (
+        "this year",
+        "next year",
+        "long term",
+        "over time",
+        "eventually",
+        "future",
+    ),
+}
+
+_POSITIVE_KEYWORDS = {"confident", "ready", "excited", "hope", "optimistic", "eager"}
+_NEGATIVE_KEYWORDS = {
+    "worried",
+    "anxious",
+    "afraid",
+    "stressed",
+    "concerned",
+    "stuck",
+    "doubt",
+}
+
+
+@dataclass(frozen=True)
+class ContextProfile:
+    """Structured representation of a querent's question."""
+
+    question: str
+    focuses: Sequence[str]
+    timeframe: str
+    sentiment: str
+    highlighted_terms: Sequence[str]
+
+    @property
+    def primary_focus(self) -> str | None:
+        return self.focuses[0] if self.focuses else None
+
+
+def _normalise_question(question: str) -> str:
+    return " ".join(question.strip().split())
+
+
+def _extract_terms(question: str) -> List[str]:
+    tokens = re.findall(r"[A-Za-z']+", question.lower())
+    return sorted(set(tokens))
+
+
+def _detect_focuses(lower_question: str) -> List[str]:
+    focuses: List[str] = []
+    for theme, lexicon in THEME_KEYWORDS.items():
+        if any(keyword in lower_question for keyword in lexicon):
+            focuses.append(theme)
+    return focuses
+
+
+def _detect_timeframe(lower_question: str) -> str:
+    for label, lexicon in _TIMEFRAME_KEYWORDS.items():
+        if any(keyword in lower_question for keyword in lexicon):
+            return label
+    return "open"
+
+
+def _detect_sentiment(terms: Sequence[str]) -> str:
+    if any(term in _NEGATIVE_KEYWORDS for term in terms):
+        return "concerned"
+    if any(term in _POSITIVE_KEYWORDS for term in terms):
+        return "hopeful"
+    return "curious"
+
+
+def analyze_question(question: str) -> ContextProfile:
+    """Return a :class:`ContextProfile` derived from ``question``."""
+
+    normalised = _normalise_question(question)
+    lowered = normalised.lower()
+    focuses = _detect_focuses(lowered)
+    terms = _extract_terms(lowered)
+    timeframe = _detect_timeframe(lowered)
+    sentiment = _detect_sentiment(terms)
+    if not focuses:
+        focuses = ["general"]
+    return ContextProfile(
+        question=normalised,
+        focuses=tuple(focuses),
+        timeframe=timeframe,
+        sentiment=sentiment,
+        highlighted_terms=tuple(term for term in terms if len(term) > 3),
+    )

--- a/src/tarotteller/engine.py
+++ b/src/tarotteller/engine.py
@@ -1,0 +1,126 @@
+"""Interpretation engine that ties spreads to contextual insights."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+from .context import ContextProfile
+from .knowledge import TarotKnowledgeBase
+from .spreads import SpreadPlacement, SpreadReading
+
+
+@dataclass
+class PersonalizedInsight:
+    """A contextual message generated for a drawn card."""
+
+    placement_index: int
+    title: str
+    card_name: str
+    orientation: str
+    prompt: str
+    message: str
+
+
+class InterpretationEngine:
+    """Produce contextual readings that blend spreads with question intent."""
+
+    def __init__(self, knowledge_base: TarotKnowledgeBase):
+        self._knowledge_base = knowledge_base
+
+    def _select_focus(self, card_themes: Sequence[str], focuses: Sequence[str]) -> str:
+        for focus in focuses:
+            if focus in card_themes:
+                return focus
+        if card_themes:
+            return card_themes[0]
+        return focuses[0] if focuses else "general"
+
+    def _build_insight(
+        self,
+        placement: SpreadPlacement,
+        profile: ContextProfile,
+    ) -> PersonalizedInsight:
+        card = placement.card
+        themes = self._knowledge_base.themes_for_card(card.card)
+        focus = self._select_focus(themes, profile.focuses)
+        message = self._knowledge_base.insight_for(card, focus)
+        return PersonalizedInsight(
+            placement_index=placement.position.index,
+            title=placement.position.title,
+            card_name=card.card.name,
+            orientation=card.orientation,
+            prompt=placement.position.prompt,
+            message=message,
+        )
+
+    def insights_for_reading(
+        self, reading: SpreadReading, profile: ContextProfile
+    ) -> List[PersonalizedInsight]:
+        return [self._build_insight(placement, profile) for placement in reading.placements]
+
+    def render_personalised_summary(
+        self, reading: SpreadReading, profile: ContextProfile
+    ) -> str:
+        """Return a multi-line personalised summary for ``reading``."""
+
+        insights = self.insights_for_reading(reading, profile)
+        lines: List[str] = []
+        lines.append("Personalized Insight")
+        lines.append("-------------------")
+        lines.append(f"Question : {profile.question}")
+        if profile.focuses:
+            lines.append(f"Focus    : {', '.join(profile.focuses)}")
+        lines.append(f"Timeframe: {profile.timeframe.replace('_', ' ')}")
+        lines.append(f"Mood     : {profile.sentiment}")
+        if profile.highlighted_terms:
+            lines.append(
+                "Signals  : " + ", ".join(sorted(profile.highlighted_terms)[:6])
+            )
+        lines.append("")
+        for insight in insights:
+            header = (
+                f"{insight.placement_index}. {insight.title} — "
+                f"{insight.card_name} ({insight.orientation})"
+            )
+            lines.append(header)
+            lines.append("   " + insight.prompt)
+            lines.append("   " + insight.message)
+            lines.append("")
+        lines.append(
+            "Let these highlights guide follow-up actions and keep logging feedback to "
+            "train the model on what resonates."
+        )
+        return "\n".join(lines).strip()
+
+    def render_for_cards(
+        self, cards: Iterable[PersonalizedInsight], profile: ContextProfile
+    ) -> str:
+        lines: List[str] = []
+        lines.append("Personalized Insight")
+        lines.append("-------------------")
+        lines.append(f"Question : {profile.question}")
+        if profile.focuses:
+            lines.append(f"Focus    : {', '.join(profile.focuses)}")
+        lines.append(f"Timeframe: {profile.timeframe.replace('_', ' ')}")
+        lines.append(f"Mood     : {profile.sentiment}")
+        lines.append("")
+        for insight in cards:
+            header = f"{insight.card_name} ({insight.orientation})"
+            lines.append(header)
+            lines.append("   " + insight.message)
+            lines.append("")
+        return "\n".join(lines).strip()
+
+    def build_card_insight(self, drawn_card, profile: ContextProfile) -> PersonalizedInsight:
+        themes = self._knowledge_base.themes_for_card(drawn_card.card)
+        focus = self._select_focus(themes, profile.focuses)
+        message = self._knowledge_base.insight_for(drawn_card, focus)
+        return PersonalizedInsight(
+            placement_index=0,
+            title="",  # Not used for direct draws
+            card_name=drawn_card.card.name,
+            orientation=drawn_card.orientation,
+            prompt="",
+            message=message,
+        )

--- a/src/tarotteller/knowledge.py
+++ b/src/tarotteller/knowledge.py
@@ -1,0 +1,183 @@
+"""Lightweight tarot knowledge base and reasoning helpers."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Iterable, List, Mapping, Sequence
+
+from .deck import DrawnCard, TarotCard
+
+# Keyword lexicon connecting high level themes to vocabulary that commonly
+# appears in tarot interpretations.  The lexicon intentionally overlaps with the
+# card metadata so that we can infer relevant themes from card keywords and
+# descriptions without an external database.
+THEME_KEYWORDS: Mapping[str, Sequence[str]] = {
+    "love": (
+        "love",
+        "relationship",
+        "union",
+        "romance",
+        "heart",
+        "emotion",
+        "partnership",
+        "marriage",
+        "affection",
+        "fertility",
+        "compassion",
+    ),
+    "career": (
+        "career",
+        "work",
+        "ambition",
+        "leadership",
+        "enterprise",
+        "project",
+        "promotion",
+        "skill",
+        "achievement",
+    ),
+    "finance": (
+        "money",
+        "finance",
+        "wealth",
+        "abundance",
+        "material",
+        "resources",
+        "security",
+        "investment",
+    ),
+    "health": (
+        "health",
+        "healing",
+        "recovery",
+        "wellness",
+        "stress",
+        "balance",
+        "vitality",
+    ),
+    "spirituality": (
+        "spirit",
+        "intuition",
+        "soul",
+        "faith",
+        "destiny",
+        "purpose",
+        "guidance",
+        "karma",
+    ),
+    "creativity": (
+        "creativity",
+        "art",
+        "inspiration",
+        "imagination",
+        "vision",
+        "expression",
+        "innovation",
+    ),
+    "change": (
+        "change",
+        "transition",
+        "transformation",
+        "rebirth",
+        "ending",
+        "beginning",
+        "shift",
+    ),
+}
+
+
+def _natural_join(words: Sequence[str]) -> str:
+    """Return a human friendly comma separated list."""
+
+    if not words:
+        return ""
+    if len(words) == 1:
+        return words[0]
+    if len(words) == 2:
+        return f"{words[0]} and {words[1]}"
+    return f"{', '.join(words[:-1])}, and {words[-1]}"
+
+
+@dataclass(frozen=True)
+class ThemeMatch:
+    """A theme along with its support score for a specific card."""
+
+    theme: str
+    score: int
+
+
+class TarotKnowledgeBase:
+    """Infer tarot themes and generate contextual insights."""
+
+    def __init__(self, cards: Iterable[TarotCard]):
+        self._cards = {card.name: card for card in cards}
+        self._cache: dict[str, List[ThemeMatch]] = {}
+
+    def _text_snippets(self, card: TarotCard) -> List[str]:
+        snippets: List[str] = []
+        snippets.extend(card.keywords)
+        snippets.extend(card.reversed_keywords)
+        snippets.append(card.description)
+        if card.suit:
+            snippets.append(card.suit)
+        if card.element:
+            snippets.append(card.element)
+        return [snippet.lower() for snippet in snippets]
+
+    def themes_for_card(self, card: TarotCard) -> List[str]:
+        """Return ordered themes that resonate with ``card``."""
+
+        if card.name in self._cache:
+            return [match.theme for match in self._cache[card.name]]
+
+        snippets = self._text_snippets(card)
+        scores: Counter[str] = Counter()
+        for theme, lexicon in THEME_KEYWORDS.items():
+            lowered = [token.lower() for token in lexicon]
+            for snippet in snippets:
+                if any(word in snippet for word in lowered):
+                    scores[theme] += 1
+
+        # Provide sensible defaults when no keywords matched.
+        if not scores:
+            if card.arcana.lower() == "major":
+                scores["spirituality"] = 1
+            elif (card.suit or "").lower() == "cups":
+                scores["love"] = 1
+            elif (card.suit or "").lower() == "pentacles":
+                scores["finance"] = 1
+            elif (card.suit or "").lower() == "wands":
+                scores["career"] = 1
+            elif (card.suit or "").lower() == "swords":
+                scores["change"] = 1
+
+        ordered = [ThemeMatch(theme=theme, score=score) for theme, score in scores.most_common()]
+        self._cache[card.name] = ordered
+        return [match.theme for match in ordered]
+
+    def insight_for(self, drawn_card: DrawnCard, focus: str) -> str:
+        """Generate a short recommendation for ``drawn_card`` within ``focus``."""
+
+        theme_keywords = set(word.lower() for word in THEME_KEYWORDS.get(focus, ()))
+        overlap = [
+            keyword
+            for keyword in drawn_card.keywords
+            if keyword.lower() in theme_keywords
+        ]
+        if not overlap:
+            # Fall back to the most characteristic keywords of the orientation.
+            overlap = list(drawn_card.keywords[:2])
+
+        descriptor = _natural_join(overlap)
+        orientation = "reversed" if drawn_card.is_reversed else "upright"
+        focus_text = focus.replace("_", " ")
+        return (
+            f"In {focus_text} matters, the {orientation} {drawn_card.card.name} encourages you to "
+            f"lean into {descriptor or 'the lesson it offers'} to stay aligned with your intent."
+        )
+
+    def resolve_card(self, name: str) -> TarotCard:
+        """Return a card by name, raising ``KeyError`` if unknown."""
+
+        return self._cards[name]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,3 +34,19 @@ def test_cli_draw_cards(capsys):
     assert exit_code == 0
     assert "Card 1:" in captured.out
     assert "(upright)" in captured.out
+
+
+def test_cli_draw_with_question(capsys):
+    exit_code = run_cli([
+        "draw",
+        "--seed",
+        "7",
+        "--spread",
+        "single",
+        "--question",
+        "What career move should I make soon?",
+    ])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Personalized Insight" in captured.out
+    assert "career" in captured.out.lower()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,10 @@
+from tarotteller.context import analyze_question
+
+
+def test_analyze_question_detects_focus_and_timeframe():
+    profile = analyze_question("Will I find love at work this year?")
+    assert profile.primary_focus == "love"
+    assert "career" in profile.focuses
+    assert profile.timeframe == "long_term"
+    assert profile.sentiment in {"hopeful", "curious", "concerned"}
+    assert "love" in profile.highlighted_terms

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -1,0 +1,15 @@
+from tarotteller.deck import DrawnCard, TarotDeck
+from tarotteller.knowledge import TarotKnowledgeBase
+
+
+def test_knowledge_identifies_themes_and_generates_insight():
+    deck = TarotDeck()
+    card = deck.get_card("Two of Cups")
+    knowledge = TarotKnowledgeBase(deck.all_cards)
+    themes = knowledge.themes_for_card(card)
+    assert "love" in themes
+
+    drawn = DrawnCard(card)
+    insight = knowledge.insight_for(drawn, "love")
+    assert "Two of Cups" in insight
+    assert "love" in insight.lower()


### PR DESCRIPTION
## Summary
- add a lightweight knowledge base, question analyzer, and interpretation engine to contextualize readings
- extend the CLI draw command with a --question flag that prints personalized insights alongside spreads or manual draws
- cover the new capabilities with tests for the analyzer, knowledge base, and CLI workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5dca5590c832c9800c5d3d223f1f9